### PR TITLE
Add a flag to allow storing response bodies in a separate file.

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
-	slowhttp "github.com/Clever/go-bench/slowhttp"
+	"io/ioutil"
 	"os"
-	"github.com/stretchr/testify/assert"
-	"testing"
 	"strings"
+	"testing"
+
+	slowhttp "github.com/clever/go-bench/slowhttp"
+	"github.com/stretchr/testify/assert"
 )
 
 func assertNoError(err error, t *testing.T) {
@@ -22,7 +24,7 @@ func TestPlayback_1(t *testing.T) {
 	l, err := slowhttp.StartServer()
 	assertNoError(err, t)
 
-	parseAndReplay(p, "http://127.0.0.1:8653", 1)
+	parseAndReplay(p, "http://127.0.0.1:8653", 1, ioutil.Discard)
 	l.Close()
 }
 

--- a/slowhttp/slowhttp.go
+++ b/slowhttp/slowhttp.go
@@ -1,4 +1,4 @@
-package main
+package slowhttp
 
 import (
 	"bufio"

--- a/slowhttp/start_server.go
+++ b/slowhttp/start_server.go
@@ -1,4 +1,4 @@
-package main
+package slowhttp
 
 import (
 	"fmt"
@@ -6,11 +6,11 @@ import (
 
 func main() {
 	server, err := StartServer()
-	if (err != nil) {
+	if err != nil {
 		panic(err)
 	}
 	defer server.Close()
-	
+
 	// continue running until user input given
 	var input string
 	if _, err := fmt.Scanf("%s", &input); err != nil {


### PR DESCRIPTION
See https://clever.atlassian.net/browse/API-487 for context.

Tested:
Ran make
Actually sent requests to a local server with the flag enabled.