### PR TITLE
Smooth out requests at high rate

### DIFF
--- a/bench.go
+++ b/bench.go
@@ -181,8 +181,6 @@ func parseAndReplay(r io.Reader, rootURL string, speed float64, bw io.Writer) {
 	var startTime time.Time
 	in := newRequestEventReader(r)
 
-	var mutex sync.Mutex
-	count := 0
 	for {
 		rec, err := in.Read()
 		if err == io.EOF {
@@ -198,21 +196,15 @@ func parseAndReplay(r io.Reader, rootURL string, speed float64, bw io.Writer) {
 		for int(float64(time.Now().Sub(startTime)/time.Millisecond)*speed) < rec.Time {
 			time.Sleep(time.Duration(100) * time.Millisecond)
 		}
-		mutex.Lock()
-		count++
-		mutex.Unlock()
 		go func() {
 			res, body := timeRequest(eventToRequest(rootURL, rec))
 			addToStats(rec, res, body, bw)
-			mutex.Lock()
-			count--
-			mutex.Unlock()
 		}()
 	}
 
-	for count > 0 {
-		time.Sleep(time.Duration(100) * time.Millisecond)
-	}
+	// Sleep for a bit to wait for the last few requests to finish. This is a bit ad-hoc,
+	// but is good enough for now.
+	time.Sleep(time.Duration(100) * time.Millisecond)
 }
 
 var outputWriter *bufio.Writer

--- a/bench.go
+++ b/bench.go
@@ -194,7 +194,7 @@ func parseAndReplay(r io.Reader, rootURL string, speed float64, bw io.Writer) {
 		}
 
 		for int(float64(time.Now().Sub(startTime)/time.Millisecond)*speed) < rec.Time {
-			time.Sleep(time.Duration(100) * time.Millisecond)
+			time.Sleep(time.Duration(1) * time.Millisecond)
 		}
 		go func() {
 			res, body := timeRequest(eventToRequest(rootURL, rec))


### PR DESCRIPTION
This change smooths out the requests at high rates. Before once we went over the rate
we slept for 100ms to wait until we should send more requests. At a high request rate this
means that we basically send a flurry of requests every 100ms, instead of spacing them
out. By only sleeping 1ms we're making it quite a bit smoother (at least at our request rates).

Also, I cleaned up some code around active requests that didn't seem very valuable and
made the code a bit more complex.