### PR TITLE
spring cleaning

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,13 +1,13 @@
 image: clever/drone-go:1.5
-script:
-  - make test
 notify:
   email:
     recipients:
-      - drone@clever.com
-  hipchat:
-    room: Clever-Dev-CI
-    token: {{hipchatToken}}
-    on_started: true
-    on_success: true
+    - drone@clever.com
+  slack:
     on_failure: true
+    on_started: false
+    on_success: false
+    webhook_url: $$slack_webhook
+script:
+- make test
+- make build

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,23 @@
+include golang.mk
+.DEFAULT_GOAL := test # override default goal set in library makefile
+
 SHELL := /bin/bash
 PKG = github.com/Clever/go-bench
 PKGS := $(shell go list ./... | grep -v /vendor)
-EXECUTABLE := go-bench
+EXECUTABLE := $(shell basename $(PKG))
 .PHONY: test vendor $(PKGS)
 
-GOVERSION := $(shell go version | grep 1.5)
-ifeq "$(GOVERSION)" ""
-  $(error must be running Go version 1.5)
-endif
-export GO15VENDOREXPERIMENT = 1
+$(eval $(call golang-version-check,1.5))
 
-GOLINT := $(GOPATH)/bin/golint
-$(GOLINT):
-	go get github.com/golang/lint/golint
-
-GODEP := $(GOPATH)/bin/godep
-$(GODEP):
-	go get -u github.com/tools/godep
+all: test build
 
 build:
 	go build -o bin/$(EXECUTABLE) $(PKG)
 
-test: $(PKG)
+test: $(PKGS)
 
-$(PKG): $(GOLINT)
-ifeq ($(LINT),1)
-	$(GOLINT) $(GOPATH)/src/$@*/**.go
-endif
-	go get -d -t $@
-ifeq ($(COVERAGE),1)
-	go test -cover -coverprofile=$(GOPATH)/src/$@/c.out $@ -test.v
-	go tool cover -html=$(GOPATH)/src/$@/c.out
-else
-	go test $@ -test.v
-endif
+$(PKGS): golang-test-all-deps
+	$(call golang-test-all,$@)
 
-vendor: $(GODEP)
-	$(GODEP) save $(PKGS)
-	find vendor/ -path '*/vendor' -type d | xargs -IX rm -r X # remove any nested vendor directories
+vendor: golang-godep-vendor-deps
+	$(call golang-godep-vendor,$(PKGS))

--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
 ## Developing
 
-go-bench is built and tested against Go 1.2.
-Ensure this is the version of Go you're running with `go version`.
-Make sure your GOPATH is set, e.g. `export GOPATH=~/go`.
-Clone the repository to a location outside your GOPATH, and symlink it to `$GOPATH/src/github.com/Clever/go-bench`.
-If you have done all of the above, then you should be able to run
-
 ```
+go get github.com/Clever/go-bench
 make
 ```
 
 ## Usage
 You can run go-bench using:
 
-	go run bench.go
+```
+go run bench.go
+```
 
 Or:
 
-	go build bench.go
-	./bench
+```
+make build
+./bin/bench
+```
 
 The following command-line flags are supported:
 
@@ -29,8 +28,10 @@ flag | required? | description
 --root | yes | URL root for requests
 
 go-bench reads requests to playback from standard input in the following format:
-	
-	time,method,path,auth,extra
+
+```
+time,method,path,auth,extra
+```
 
 item | required? | description
 :---: | :---: | :---:
@@ -42,7 +43,9 @@ extra | no | Information about the request that will be written to the output fi
 
 If you need a simple server to test your usage of go-bench, you can start one using:
 
-	go run start_server.go
+```
+go run start_server.go
+```
 
 ## Vendoring
 

--- a/bench.go
+++ b/bench.go
@@ -100,7 +100,7 @@ func timeRequest(request *http.Request) (RequestResult, []byte) {
 	defer r.Body.Close()
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		log.Println("WARNING: Error while reading response body. %s", err.Error())
+		log.Println("WARNING: Error while reading response body.", err.Error())
 	}
 	contentEndTime = time.Now().Sub(startTime).Nanoseconds()
 	return RequestResult{err, r.StatusCode, int64(len(body)), (connectEndTime) / 1000000,
@@ -147,7 +147,7 @@ func addToStats(event RequestEvent, result RequestResult, body []byte, bw io.Wri
 		}
 		bodydata, err := json.Marshal(bodyResultData{event, bodymap})
 		if err != nil {
-			log.Println("WARNING: Error marshaling body result data. %s", err.Error())
+			log.Println("WARNING: Error marshaling body result data.", err.Error())
 		}
 		bw.Write(append(bodydata, byte('\n')))
 	}()
@@ -160,7 +160,7 @@ func addToStats(event RequestEvent, result RequestResult, body []byte, bw io.Wri
 
 	requestLine := fmt.Sprintf("%s %s [%s]\n", event.Verb, event.Path, event.Extra)
 	if result.Error != nil {
-		colorPrint(8, fmt.Sprintln("%sGot error:", requestLine, result.Error))
+		colorPrint(8, fmt.Sprintf("%sGot error: %s\n", requestLine, result.Error))
 	} else {
 		resultLine := fmt.Sprintf("%sGot %d (%d bytes) in %d ms, %d ms, %d ms (%d ms)\n",
 			requestLine, result.ResponseCode, result.ContentSize, result.ConnectTime,
@@ -246,7 +246,7 @@ func main() {
 	}
 
 	parseAndReplay(os.Stdin, *rooturl, *speed, bodyWriter)
-	fmt.Println("Done!\n")
+	fmt.Println("Done!")
 	if outputWriter != nil {
 		outputWriter.Flush()
 		outputFile.Close()

--- a/golang.mk
+++ b/golang.mk
@@ -1,0 +1,121 @@
+# This is the default Clever Golang Makefile.
+# Please do not alter this file directly.
+SHELL := /bin/bash
+.PHONY: golang-godep-vendor golang-test-deps $(GODEP)
+
+# This block checks and confirms that the proper Go toolchain version is installed.
+# arg1: golang version
+define golang-version-check
+GOVERSION := $(shell go version | grep $(1))
+_ := $(if \
+	$(shell go version | grep $(1)), \
+	@echo "", \
+	$(error "must be running Go version $(1)"))
+endef
+
+export GO15VENDOREXPERIMENT=1
+
+# FGT is a utility that exits with 1 whenever any stderr/stdout output is recieved.
+FGT := $(GOPATH)/bin/fgt
+$(FGT):
+	go get github.com/GeertJohan/fgt
+
+# Godep is a tool used to manage Golang dependencies in the style of the Go 1.5
+# vendoring experiment.
+GODEP := $(GOPATH)/bin/godep
+$(GODEP):
+	go get -u github.com/tools/godep
+
+# Golint is a tool for linting Golang code for common errors.
+GOLINT := $(GOPATH)/bin/golint
+$(GOLINT):
+	go get github.com/golang/lint/golint
+
+# golang-vendor-deps installs all dependencies needed for different test cases.
+golang-godep-vendor-deps: $(GODEP)
+
+# golang-godep-vendor is a target for saving dependencies with the godep tool
+# to the vendor/ directory. All nested vendor/ directories are deleted as they
+# are not handled well by the Go toolchain.
+# arg1: pkg path
+define golang-godep-vendor
+$(GODEP) save $(1)
+@# remove any nested vendor directories
+find vendor/ -path '*/vendor' -type d | xargs -IX rm -r X
+endef
+
+# golang-fmt-deps requires the FGT tool for checking output
+golang-fmt-deps: $(FGT)
+
+# golang-fmt checks that all golang files in the pkg are formatted correctly.
+# arg1: pkg path
+define golang-fmt
+@echo "FORMATTING $(1)..."
+@$(FGT) gofmt -l=true $(GOPATH)/src/$(1)/*.go
+endef
+
+# golang-lint-deps requires the golint tool for golang linting.
+golang-lint-deps: $(GOLINT)
+
+# golang-lint calls golint on all golang files in the pkg.
+# arg1: pkg path
+define golang-lint
+@echo "LINTING $(1)..."
+@$(GOLINT) $(GOPATH)/src/$(1)/*.go
+endef
+
+# golang-lint-deps-strict requires the golint tool for golang linting.
+golang-lint-deps-strict: $(GOLINT) $(FGT)
+
+# golang-lint-strict calls golint on all golang files in the pkg and fails if any lint
+# errors are found.
+# arg1: pkg path
+define golang-lint-strict
+@echo "LINTING $(1)..."
+@$(FGT) $(GOLINT) $(GOPATH)/src/$(1)/*.go
+endef
+
+# golang-test-deps is here for consistency
+golang-test-deps:
+
+# golang-test uses the Go toolchain to run all tests in the pkg.
+# arg1: pkg path
+define golang-test
+@echo "TESTING $(1)..."
+@go test -v $(1)
+endef
+
+# golang-vet-deps is here for consistency
+golang-vet-deps:
+
+# golang-vet uses the Go toolchain to vet all the pkg for common mistakes.
+# arg1: pkg path
+define golang-vet
+@echo "VETTING $(1)..."
+@go vet $(GOPATH)/src/$(1)/*.go
+endef
+
+# golang-test-all-deps installs all dependencies needed for different test cases.
+golang-test-all-deps: golang-fmt-deps golang-lint-deps golang-test-deps golang-vet-deps
+
+# golang-test-all calls fmt, lint, vet and test on the specified pkg.
+# arg1: pkg path
+define golang-test-all
+$(call golang-fmt,$(1))
+$(call golang-lint,$(1))
+$(call golang-vet,$(1))
+$(call golang-test,$(1))
+endef
+
+# golang-test-all-deps-strict: installs all dependencies needed for different test cases.
+golang-test-all-deps-strict: golang-fmt-deps golang-lint-deps-strict golang-test-deps golang-vet-deps
+
+# golang-test-all-strict calls fmt, lint, vet and test on the specified pkg with strict
+# requirements that no errors are thrown while linting.
+# arg1: pkg path
+define golang-test-all-strict
+$(call golang-fmt,$(1))
+$(call golang-lint-strict,$(1))
+$(call golang-vet,$(1))
+$(call golang-test,$(1))
+endef

--- a/slowhttp/slowhttp.go
+++ b/slowhttp/slowhttp.go
@@ -105,7 +105,6 @@ func StartServer() (net.Listener, error) {
 	fmt.Println("Starting server!")
 	if err != nil {
 		panic(err)
-		return listener, err
 	}
 	go acceptLoop(listener)
 	return listener, nil


### PR DESCRIPTION
- Cleans up README to remove mentions of Go 1.2
- Upgrades Makefile to use golang.mk
- Fixes govet errors exposed by golang.mk :smiley_cat: